### PR TITLE
python-urllib3: python-ipaddress is only required for Python 2.x

### DIFF
--- a/recipes-devtools/python/python-urllib3.inc
+++ b/recipes-devtools/python/python-urllib3.inc
@@ -15,7 +15,6 @@ RDEPENDS_${PN} += "\
 	${PYTHON_PN}-cryptography \
 	${PYTHON_PN}-idna \
 	${PYTHON_PN}-certifi \
-	${PYTHON_PN}-ipaddress \
 	${PYTHON_PN}-pysocks \
 "
 

--- a/recipes-devtools/python/python-urllib3_1.21.1.bb
+++ b/recipes-devtools/python/python-urllib3_1.21.1.bb
@@ -1,2 +1,6 @@
 inherit setuptools
 require python-urllib3.inc
+
+RDEPENDS_${PN} += "\
+	${PYTHON_PN}-ipaddress \
+"


### PR DESCRIPTION
Move runtime dependency on python-ipaddress to python-urllib3 recipe, since this is not needed for python3-urllib3.