### PR TITLE
Add support for Native-SDK to azure-iot-sdk and http-parser

### DIFF
--- a/recipes-azure/azure-c-shared-utility/azure-c-shared-utility_1.0.43.bb
+++ b/recipes-azure/azure-c-shared-utility/azure-c-shared-utility_1.0.43.bb
@@ -58,3 +58,5 @@ FILES_${PN}-dev += "\
 FILES_${PN}-dbg += "${libdir}/.debug"
 
 RRECOMMENDS_azure-c-shared-utility-dev[nodeprrecs] = "1"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-azure/azure-iot-sdk/azure-iot-sdk_1.1.23.bb
+++ b/recipes-azure/azure-iot-sdk/azure-iot-sdk_1.1.23.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 inherit cmake python-dir
 
+RPROVIDES_nativesdk-${PN} += "nativesdk-azure-iot-sdk-c"
+RPROVIDES_nativesdk-${PN}-dev += "nativesdk-azure-iot-sdk-c-dev"
 RPROVIDES_${PN} += "azure-iot-sdk-c"
 RPROVIDES_${PN}-dev += "azure-iot-sdk-c-dev"
 
@@ -97,3 +99,5 @@ FILES_python-${PN} += "\
 RRECOMMENDS_azure-iot-sdk-dev[nodeprrecs] = "1"
 
 INSANE_SKIP_python-${PN} += "rpaths"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-azure/azure-uamqp-c/azure-uamqp-c_1.0.43.bb
+++ b/recipes-azure/azure-uamqp-c/azure-uamqp-c_1.0.43.bb
@@ -41,3 +41,5 @@ FILES_${PN}-dev += "\
 "
 
 FILES_${PN}-dbg += "${libdir}/.debug"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-azure/azure-umqtt-c/azure-umqtt-c_1.0.43.bb
+++ b/recipes-azure/azure-umqtt-c/azure-umqtt-c_1.0.43.bb
@@ -41,3 +41,5 @@ FILES_${PN}-dev += "\
 "
 
 FILES_${PN}-dbg += "${libdir}/.debug"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-support/http-parser/http-parser_2.7.0.bb
+++ b/recipes-support/http-parser/http-parser_2.7.0.bb
@@ -23,4 +23,4 @@ do_install() {
 	install -m 0644 ${S}/*.h ${D}${includedir}
 }
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Dear Maintainers,

I added the support for Native SDK to  *http-parser* and *azure-iot-sdk* recipes.

I hope you will find it useful.

King Regards,
Gaël