### PR TITLE
IBM IoTF Embedded C SDK: Fix for various issues

### DIFF
--- a/recipes-ibm/ibm-iotf-embeddedc/files/Add-aditional-options-to-sample-apps.patch
+++ b/recipes-ibm/ibm-iotf-embeddedc/files/Add-aditional-options-to-sample-apps.patch
@@ -1,0 +1,77 @@
+From 796c934b3294871cb8ccb566ff6a9ae78d3ea4df Mon Sep 17 00:00:00 2001
+From: Vivek Chandra <vivek.chandrax.amancha@intel.com>
+Date: Wed, 21 Mar 2018 19:45:48 +0530
+Subject: [PATCH] Add aditional options to sample apps
+
+---
+ samples/sampleDevice.c  | 15 +++++++++------
+ samples/sampleGateway.c | 14 ++++++++++----
+ 2 files changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/samples/sampleDevice.c b/samples/sampleDevice.c
+index e1d78ea..5af14a2 100644
+--- a/samples/sampleDevice.c
++++ b/samples/sampleDevice.c
+@@ -40,7 +40,6 @@ int main(int argc, char const *argv[])
+ 	int rc = -1;
+ 
+ 	iotfclient  client;
+-
+ 	//catch interrupt signal
+ 	signal(SIGINT, sigHandler);
+ 	signal(SIGTERM, sigHandler);
+@@ -48,16 +47,20 @@ int main(int argc, char const *argv[])
+ 	char* configFilePath;
+ 
+ 	if(isEMBDCHomeDefined()){
+-
+ 	    getSamplesPath(&configFilePath);
+ 	    configFilePath = realloc(configFilePath,strlen(configFilePath)+15);
+ 	    strcat(configFilePath,"device.cfg");
+         }
+-	else{
+-	    printf("IOT_EMBDC_HOME is not defined\n");
+-	    printf("Define IOT_EMBDC_HOME to client library path to execute samples\n");
++	//to handle if EMBDCHome not defined
++	else if(argc > 1) {
++	    configFilePath = (char*)malloc(sizeof(char)*(strlen(argv[1])+3));
++            strcpy(configFilePath,argv[1]);
++        } 
++	else {
++	    printf("Pass the absolute path of the config file as command line argument ex: ./sampleDevice <path-to-config>/<config-file-name> or ");
++	    printf("Please define IOT_EMBDC_HOME\n");
+ 	    return -1;
+-        }
++	}
+ 
+ 	rc = initialize_configfile(&client, configFilePath,0);
+ 	free(configFilePath);
+diff --git a/samples/sampleGateway.c b/samples/sampleGateway.c
+index 0d98f53..202ad45 100644
+--- a/samples/sampleGateway.c
++++ b/samples/sampleGateway.c
+@@ -55,11 +55,17 @@ int main(int argc, char const *argv[])
+ 	    configFilePath = realloc(configFilePath,strlen(configFilePath)+15);
+ 	    strcat(configFilePath,"gateway.cfg");
+         }
+-	else{
+-	    printf("IOT_EMBDC_HOME is not defined\n");
+-	    printf("Define IOT_EMBDC_HOME to client library path to execute samples\n");
++	//to handle if EMBDCHome not defined
++	else if(argc > 1) {
++	    configFilePath = (char*)malloc(sizeof(char)*(strlen(argv[1])+3));
++	    strcpy(configFilePath,argv[1]); 
++        } 
++	else {
++	    printf("Pass the absolute path of the config file as command line argument ex: ./sampleGateway <path-to-config>/<config-file-name> or ");
++	    printf("Define IOT_EMBDC_HOME to client library path to execute samples\n");	
+ 	    return -1;
+-        }
++	}
++
+ 
+ 	rc = initialize_configfile(&client, configFilePath,1);
+ 	free(configFilePath);
+-- 
+2.7.4
+

--- a/recipes-ibm/ibm-iotf-embeddedc/ibm-iotf-embeddedc_1.0.bb
+++ b/recipes-ibm/ibm-iotf-embeddedc/ibm-iotf-embeddedc_1.0.bb
@@ -15,6 +15,7 @@ SRC_URI = "\
 	file://0001-Fix-dependencies.patch \
 	file://0002-Fix-cjson-library.patch \
 	file://0003-Remove-host-library-paths.patch \
+	file://Add-aditional-options-to-sample-apps.patch \
 "
 SRCREV = "809af3b63294d0c5302cc15e3652c65843907cf2"
 

--- a/recipes-ibm/ibm-iotf-embeddedc/ibm-iotf-embeddedc_1.0.bb
+++ b/recipes-ibm/ibm-iotf-embeddedc/ibm-iotf-embeddedc_1.0.bb
@@ -59,6 +59,7 @@ do_install() {
 	install -m 0755 ${WORKDIR}/build/samples/sampleGateway ${D}${datadir}/ibmiotfsdk/samples/c/
 	install -m 0644 ${S}/samples/device.cfg ${D}${datadir}/ibmiotfsdk/samples/c/
 	install -m 0644 ${S}/samples/gateway.cfg ${D}${datadir}/ibmiotfsdk/samples/c/
+	install -m 0644 ${WORKDIR}/git/IoTFoundation.pem ${D}${datadir}/ibmiotfsdk/
 }
 
 FILES_${PN} += "\
@@ -79,6 +80,7 @@ FILES_${PN}-samples += "\
 	${datadir}/ibmiotfsdk/samples/c/sampleGateway \
 	${datadir}/ibmiotfsdk/samples/c/device.cfg \
 	${datadir}/ibmiotfsdk/samples/c/gateway.cfg \
+	${datadir}/ibmiotfsdk/IoTFoundation.pem \
 "
 
 INSANE_SKIP_${PN} += "rpaths"


### PR DESCRIPTION
IBM IoTF Embedded C SDK: Fix certificate file not being installed for testing C samples and added option to specify config path as command line argument for Embedded C SDK samples 