### PR TITLE
Address npm cache clear error

### DIFF
--- a/recipes-azure/iothub-explorer/node-iothub-explorer_1.1.19.bb
+++ b/recipes-azure/iothub-explorer/node-iothub-explorer_1.1.19.bb
@@ -45,7 +45,7 @@ SRC_NAME = "iothub-explorer"
 do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 
-	npm cache clear
+	npm cache clear --force
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install
 	npm prune --production
 

--- a/recipes-azure/node-red/node-red-contrib-azureiothubnode_0.1.23.bb
+++ b/recipes-azure/node-red/node-red-contrib-azureiothubnode_0.1.23.bb
@@ -47,7 +47,7 @@ do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 
 	cd ${SRC_DIR}
-	npm cache clear
+	npm cache clear --force
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install
 	npm prune --production
 

--- a/recipes-google-cloud/node-red-contrib-google-cloud/node-red-contrib-google-cloud_0.0.1.bb
+++ b/recipes-google-cloud/node-red-contrib-google-cloud/node-red-contrib-google-cloud_0.0.1.bb
@@ -44,7 +44,7 @@ do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 	
 	# Clear cache
-	npm cache clear
+	npm cache clear --force
 
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install
 	npm prune --production

--- a/recipes-ibm/node-red-contrib-ibm-watson-iot/node-red-contrib-ibm-watson-iot_0.2.8.bb
+++ b/recipes-ibm/node-red-contrib-ibm-watson-iot/node-red-contrib-ibm-watson-iot_0.2.8.bb
@@ -40,7 +40,7 @@ do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 	
 	# Clear cache
-	npm cache clear
+	npm cache clear --force
 
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install
 	npm prune --production

--- a/recipes-node-red/node-red-contrib-upm/node-red-contrib-upm_0.3.5.bb
+++ b/recipes-node-red/node-red-contrib-upm/node-red-contrib-upm_0.3.5.bb
@@ -48,7 +48,7 @@ do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 	
 	# Clear cache
-	npm cache clear
+	npm cache clear --force
 
 	# Install
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install

--- a/recipes-node-red/node-red/node-red.inc
+++ b/recipes-node-red/node-red/node-red.inc
@@ -40,7 +40,7 @@ do_compile() {
 	export NPM_CONFIG_CACHE="${NPM_CACHE_DIR}"
 	
 	# Clear cache
-	npm cache clear
+	npm cache clear --force
 
 	# Install
 	npm --registry=${NPM_REGISTRY} --arch=${NPM_ARCH} --target_arch=${NPM_ARCH} ${NPM_INSTALL_FLAGS} install


### PR DESCRIPTION
With npm 5.x and nodejs 8.x, you might see the following error:

| DEBUG: Executing shell function do_compile
| npm ERR! As of npm@5, the npm cache self-heals from corruption issues
and data extracted from the cache is guaranteed to be valid. If you want
to make sure everything is consistent, use 'npm cache verify' instead.
| npm ERR!
| npm ERR! If you're sure you want to delete the entire cache, rerun
this command with --force.

This might be a npm issue, which has been reported here:
https://github.com/npm/npm/issues/18894

So we add --force to workaround the error until upstream npm fixes it.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>