### PR TITLE
node-red-contrib-azureiothubnode: add RDEPENDS for bash

### DIFF
--- a/recipes-azure/node-red/node-red-contrib-azureiothubnode_0.1.23.bb
+++ b/recipes-azure/node-red/node-red-contrib-azureiothubnode_0.1.23.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7efa302969517c58e8c15e72b714abf0"
 
 DEPENDS = "nodejs-native"
-RDEPENDS_${PN} += "node-red"
+RDEPENDS_${PN} += "node-red bash"
 
 PR = "r0"
 


### PR DESCRIPTION
Resolve the following error:
```ERROR: node-red-contrib-azureiothubnode-0.1.23-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.```