### PR TITLE
layer.conf: update LAYERSERIES_COMPAT `sumo' -> `thud'

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,7 +8,7 @@ BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "iot-cloud"
 BBFILE_PATTERN_iot-cloud:= "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot-cloud = "10"
-LAYERSERIES_COMPAT_iot-cloud = "sumo"
+LAYERSERIES_COMPAT_iot-cloud = "thud"
 LAYERDEPENDS_iot-cloud = "\
     openembedded-layer \
     meta-python \


### PR DESCRIPTION
Since `9ec5a8a layer.conf: Drop sumo from LAYERSERIES_CORENAMES' and
`9867924 layer.conf: Add thud to LAYERSERIES_CORENAMES' applied in oe-core,
update LAYERSERIES_COMPAT `sumo' -> `thud'

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>