### PR TITLE
Remove .git/hooks/fsmonitor-watchman.sample from node-red-contrib-ibm-watson-iot recipe

### DIFF
--- a/recipes-ibm/node-red-contrib-ibm-watson-iot/node-red-contrib-ibm-watson-iot_0.2.8.bb
+++ b/recipes-ibm/node-red-contrib-ibm-watson-iot/node-red-contrib-ibm-watson-iot_0.2.8.bb
@@ -49,6 +49,7 @@ do_compile() {
 do_install() {
     install -d ${D}${NODE_MODULES_DIR}
     cp -r ${S} ${D}${NODE_MODULES_DIR}/${BPN}
+    rm -r ${D}${NODE_MODULES_DIR}/${BPN}/.git/hooks/fsmonitor-watchman.sample
 }
 
 PACKAGES = "${PN}"


### PR DESCRIPTION
Prevent this bitbake error
ERROR: node-red-contrib-ibm-watson-iot-0.2.8-r0 do_package_qa: QA Issue: /usr/lib/node_modules/node-red-contrib-ibm-watson-iot/.git/hooks/fsmonitor-watchman.sample contained in package node-red-contrib-ibm-watson-iot requires /usr/bin/perl, but no providers found in RDEPENDS_node-red-contrib-ibm-watson-iot? [file-rdeps]