### PR TITLE
Added recipe for Rclone version 1.49.0

### DIFF
--- a/recipes-connectivity/rclone/rclone_1.49.0.bb
+++ b/recipes-connectivity/rclone/rclone_1.49.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Rclone - rsync for cloud storage. "
+DESCRIPTION = "Sync files to and from many cloud storage providers like AWS S3, Google Cloud, Azure and many more"
+AUTHOR = "Nishant Poorswani <nishantpoorswani@gmail.com>"
+HOMEPAGE = "https://rclone.org/"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/rclone/rclone/COPYING;md5=bed161b82a1ecab65ff7ba3c3b960439"
+
+RDEPENDS_${PN}-dev = "python \
+    bash \
+"
+
+inherit go
+
+GO_IMPORT = "github.com/rclone/rclone"
+
+SRC_URI = "git://${GO_IMPORT};tag=v${PV}"
+
+PR = "r0"
+
+do_install_prepend(){
+    rm -f ${B}/${GO_BUILD_BINDIR}/gen
+    rm -f ${B}/${GO_BUILD_BINDIR}/test_all
+    rm -f ${B}/${GO_BUILD_BINDIR}/test_vfs
+}


### PR DESCRIPTION
Rclone is used to sync data to different cloud platforms like Google Cloud, Azure, AWS S3, Alibaba cloud and many more

Signed-off-by: nishantpoorswani <nishantpoorswani@gmail.com>