### PR TITLE
Misc fixes and Mapbox recipe

### DIFF
--- a/recipes-aws/python/python-boto3.inc
+++ b/recipes-aws/python/python-boto3.inc
@@ -14,3 +14,5 @@ RDEPENDS_${PN} = "\
 "
 
 inherit pypi
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-aws/python/python-botocore.inc
+++ b/recipes-aws/python/python-botocore.inc
@@ -27,6 +27,7 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-html \
     ${PYTHON_PN}-urllib3 \
     ${PYTHON_PN}-logging \
+    ${PYTHON_PN}-unixadmin \
 "
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-aws/python/python-botocore.inc
+++ b/recipes-aws/python/python-botocore.inc
@@ -28,3 +28,5 @@ RDEPENDS_${PN} = "\
     ${PYTHON_PN}-urllib3 \
     ${PYTHON_PN}-logging \
 "
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-aws/python/python3-s3transfer_0.2.1.bb
+++ b/recipes-aws/python/python3-s3transfer_0.2.1.bb
@@ -4,3 +4,5 @@ require python-s3transfer.inc
 RDEPENDS_${PN} += "\
     ${PYTHON_PN}-multiprocessing \
 "
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python3-jmespath_0.9.3.bb
+++ b/recipes-devtools/python/python3-jmespath_0.9.3.bb
@@ -8,3 +8,5 @@ RDEPENDS_${PN} += "\
 ALTERNATIVE_${PN} = "jmespath"
 ALTERNATIVE_LINK_NAME[jmespath] = "${bindir}/jp.py"
 ALTERNATIVE_PRIORITY = "30"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python/python3-mapbox_0.18.0.bb
+++ b/recipes-devtools/python/python3-mapbox_0.18.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "A Python client for Mapbox services"
+HOMEPAGE = "https://pypi.org/project/mapbox/"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI[md5sum] = "7e5a55af6054f9d0681313855814512c"
+SRC_URI[sha256sum] = "3e9a098524a6b855f39fd5e773fb21526ef9660291f12b147e98fd44c7573e0b"
+
+inherit pypi setuptools3
+
+RDEPENDS_${PN} += "\
+    python3-boto3 \
+    python3-cachecontrol \
+    python3-dateutil \
+    python3-iso3166 \
+    python3-polyline \
+    python3-requests \
+    python3-uritemplate \
+"
+
+RDEPENDS_${PN} += "python3-core python3-json python3-netclient python3-numbers"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This PR adds native and nativesdk support to a number of Python recipes, and a missing RDEPENDS for botocore. Finally, it adds a new recipe for exercising the Mapbox API.