### PR TITLE
layer.conf: move to next release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILES := "\
 BBFILE_COLLECTIONS += "iot-cloud"
 BBFILE_PATTERN_iot-cloud:= "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot-cloud = "10"
-LAYERSERIES_COMPAT_iot-cloud = "warrior zeus"
+LAYERSERIES_COMPAT_iot-cloud = "zeus dunfell"
 LAYERDEPENDS_iot-cloud = "\
     core \
     openembedded-layer \


### PR DESCRIPTION
poky master now supports only dunfell, so let's move up by one release.

Signed-off-by: Martin Kelly <mkelly@xevo.com>