### PR TITLE
Add recipe for azure-uhttp-c

### DIFF
--- a/recipes-azure/azure-uhttp-c/azure-uhttp-c.inc
+++ b/recipes-azure/azure-uhttp-c/azure-uhttp-c.inc
@@ -1,0 +1,23 @@
+inherit cmake
+
+DEPENDS = "\
+    azure-c-shared-utility \
+"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+EXTRA_OECMAKE += "\
+    -Dskip_samples:BOOL=ON \
+    -Duse_installed_dependencies:BOOL=ON \
+"
+
+sysroot_stage_all_append () {
+    sysroot_stage_dir ${D}${exec_prefix}/cmake ${SYSROOT_DESTDIR}${exec_prefix}/cmake
+}
+
+FILES_${PN}-dev += "\
+    ${exec_prefix}/cmake \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-azure/azure-uhttp-c/azure-uhttp-c_2020.1.22.bb
+++ b/recipes-azure/azure-uhttp-c/azure-uhttp-c_2020.1.22.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Microsoft Azure - HTTP Library written in C"
+HOMEPAGE = "https://github.com/Azure/azure-uhttp-c"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b98fddd052bb2f5ddbcdbd417ffb26a8"
+
+SRC_URI = "\
+    git://github.com/Azure/azure-uhttp-c.git \
+"
+
+SRCREV = "b67a6bfa0d018a8a23176ee214e46c208fc323c3"
+
+PR = "r0"
+
+require ${BPN}.inc


### PR DESCRIPTION
When trying to build an application, I ran into some issues with libraries not being found (see [this issue](https://github.com/intel-iot-devkit/meta-iot-cloud/issues/70)). This recipe builds the [Azure HTTP library](https://github.com/Azure/azure-uhttp-c) I was missing.