### PR TITLE
Adding http and edge to azure-iot-sdk-c packageconfig

### DIFF
--- a/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c.inc
+++ b/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c.inc
@@ -13,9 +13,11 @@ SRC_URI += "\
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
-PACKAGECONFIG ??= "amqp mqtt"
+PACKAGECONFIG ??= "amqp mqtt http edge"
 PACKAGECONFIG[amqp] = "-Duse_amqp:BOOL=ON, -Duse_amqp:BOOL=OFF, azure-uamqp-c"
 PACKAGECONFIG[mqtt] = "-Duse_mqtt:BOOL=ON, -Duse_mqtt:BOOL=OFF, azure-umqtt-c"
+PACKAGECONFIG[http] = "-Duse_http:BOOL=ON, -Duse_http:BOOL=OFF, azure-uhttp-c"
+PACKAGECONFIG[edge] = "-Duse_edge_modules:BOOL=ON, -Duse_edge_modules:BOOL=OFF"
 
 EXTRA_OECMAKE = "\
     -Dbuild_as_dynamic:BOOL=ON \
@@ -24,6 +26,12 @@ EXTRA_OECMAKE = "\
     -Dbuild_service_client:BOOL=OFF \
     -Dbuild_provisioning_service_client:BOOL=OFF \
 "
+
+# See solution at https://stackoverflow.com/a/59029698/1446624
+do_configure_prepend() {
+	cd ${S}
+	git submodule update --init --recursive
+}
 
 sysroot_stage_all_append () {
     sysroot_stage_dir ${D}${exec_prefix}/cmake ${SYSROOT_DESTDIR}${exec_prefix}/cmake


### PR DESCRIPTION
When trying to build an application, I ran into some issues with libraries not being found (see [this issue](https://github.com/intel-iot-devkit/meta-iot-cloud/issues/70)). This pull request is to add options to build these libraries while building azure-iot-sdk-c. It is also dependent on the recipe added in [this pull request](https://github.com/intel-iot-devkit/meta-iot-cloud/pull/71)

Note: the added `do_configure_prepend()` is needed to initialize the submodules of the azure-iot-sdk-c repository before building. Without this, trying to build anything that needs the submodules (for example, using the use_edge_modules flag with the build) will fail because it cannot find the files (because they aren't there)!