### PR TITLE
Make sure the main package is build even if empty

### DIFF
--- a/recipes-azure/umock-c/umock-c.inc
+++ b/recipes-azure/umock-c/umock-c.inc
@@ -19,4 +19,7 @@ FILES_${PN}-dev += "\
     ${exec_prefix}/cmake \
 "
 
+# main package is empty, but -dev had a hard dependency. enforce creation
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-azure/umock-c/umock-c.inc
+++ b/recipes-azure/umock-c/umock-c.inc
@@ -19,7 +19,6 @@ FILES_${PN}-dev += "\
     ${exec_prefix}/cmake \
 "
 
-# main package is empty, but -dev had a hard dependency. enforce creation
 ALLOW_EMPTY_${PN} = "1"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The -dev package has a dependency to the main package when 
creating the SDK. Enforce the package creation.