### PR TITLE
Enforce creation of main package of umock-c even if empty

### DIFF
--- a/recipes-azure/umock-c/umock-c.inc
+++ b/recipes-azure/umock-c/umock-c.inc
@@ -19,4 +19,7 @@ FILES_${PN}-dev += "\
     ${exec_prefix}/cmake \
 "
 
+# main package is empty, but -dev had a hard dependency. enforce creation
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The -dev package has a hard dependency on the base package. Ensure that is present to fix a failure when generating the SDK.