### PR TITLE
openssl: Only apply this bbappend to 1.1.1g

### DIFF
--- a/recipes-connectivity/openssl/openssl_1.1.1%.bbappend
+++ b/recipes-connectivity/openssl/openssl_1.1.1%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://Fix-aarch64-static-linking-into-shared-libraries.patch"
+SRC_URI += "${@bb.utils.contains_any('PV', '1.1.1f 1.1.1g 1.1.1h', 'file://Fix-aarch64-static-linking-into-shared-libraries.patch', '', d)}"
 


### PR DESCRIPTION
Upstream appears to have fixed the static linking issue in the 1.1.1i release.
openembedded-core master and gatesgarth are on 1.1.1i, but doesn't hurt to keep it
around.

https://github.com/openssl/openssl/issues/10842
https://github.com/openssl/openssl/pull/11464
https://github.com/openssl/openssl/commit/d741debb320bf54e8575d35603a44d4eb40fa1f9

Signed-off-by: Peter Scamardo <peter.scamardo@arthrex.com>