### PR TITLE
openssl: Apply patch to 1.1.1f/g/h

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,5 +17,3 @@ LAYERDEPENDS_iot-cloud = "\
     meta-python \
     networking-layer \
 "
-
-BB_DANGLINGAPPENDS_WARNONLY ?= "true"

--- a/recipes-connectivity/openssl/openssl_1.1.1%.bbappend
+++ b/recipes-connectivity/openssl/openssl_1.1.1%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "${@bb.utils.contains_any('PV', '1.1.1f 1.1.1g 1.1.1h', 'file://Fix-aarch64-static-linking-into-shared-libraries.patch', '', d)}"
+

--- a/recipes-connectivity/openssl/openssl_1.1.1g.bbappend
+++ b/recipes-connectivity/openssl/openssl_1.1.1g.bbappend
@@ -1,4 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-SRC_URI += "file://Fix-aarch64-static-linking-into-shared-libraries.patch"
-


### PR DESCRIPTION
To prevent dangling append errors, perform the detection inside the
SRC_URI, mirrors f9b0f81 on gatesgarth.

Also, remove the temporary override in 8deeed3