### PR TITLE
recipes-aws: Use SRCREV to replace tag

### DIFF
--- a/recipes-aws/aws-c-auth/aws-c-auth_0.5.2.bb
+++ b/recipes-aws/aws-c-auth/aws-c-auth_0.5.2.bb
@@ -11,9 +11,12 @@ DEPENDS += "\
     aws-c-http \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.5.2
+SRCREV = "c74534c13264868bbbd14b419c291580d3dd9141"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-cal/aws-c-cal_0.5.6.bb
+++ b/recipes-aws/aws-c-cal/aws-c-cal_0.5.6.bb
@@ -16,9 +16,12 @@ RDEPENDS_${PN} += " \
 "
 
 SRC_URI = "\
-    git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+    git://github.com/awslabs/${BPN}.git;branch=main \
     file://Build-static-and-shared-libs.patch \
 "
+
+# v0.5.6
+SRCREV = "936ec2c9c5ef9f2eff3fea37b5a83fd15924c4b4"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-common/aws-c-common_0.5.11.bb
+++ b/recipes-aws/aws-c-common/aws-c-common_0.5.11.bb
@@ -6,9 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit cmake
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.5.11
+SRCREV = "8f3ac3f087d56287eb7f428880dec134a3aa81f3"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-compression/aws-c-compression_0.2.11.bb
+++ b/recipes-aws/aws-c-compression/aws-c-compression_0.2.11.bb
@@ -10,9 +10,12 @@ DEPENDS += "\
     aws-c-common \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
+
+# v0.2.11
+SRCREV = "25cd4134377b6e2ed787d42a3a221582bdc1fa57"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
+++ b/recipes-aws/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
@@ -12,9 +12,12 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.2.7
+SRCREV = "e87537be561d753ec82e783bc0929b1979c585f8"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-http/aws-c-http_0.6.4.bb
+++ b/recipes-aws/aws-c-http/aws-c-http_0.6.4.bb
@@ -11,9 +11,12 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
+
+# v0.6.4
+SRCREV = "fa1692ae103dcc40e3d0a9db1b29acfc204a294e"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-io/aws-c-io_0.9.9.bb
+++ b/recipes-aws/aws-c-io/aws-c-io_0.9.9.bb
@@ -12,9 +12,12 @@ DEPENDS += "\
     s2n \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
+
+# v0.9.9
+SRCREV = "977065a455158fffa1c33214b33aa2b7fc273416"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-iot/aws-c-iot_0.0.5.bb
+++ b/recipes-aws/aws-c-iot/aws-c-iot_0.0.5.bb
@@ -10,9 +10,12 @@ DEPENDS += "\
     aws-c-mqtt \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.0.5
+SRCREV = "f2057934f5ea9072c47d42babe77e8d241982c90"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-aws/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -10,9 +10,12 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.7.6
+SRCREV = "0a70bf814845e487b7e4862af7ad9e4a1199b5f4"
 
 PR = "r0"
 

--- a/recipes-aws/aws-c-s3/aws-c-s3_0.1.16.bb
+++ b/recipes-aws/aws-c-s3/aws-c-s3_0.1.16.bb
@@ -10,9 +10,12 @@ DEPENDS += "\
     aws-c-auth \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.1.16
+SRCREV = "cab7afd181c22029f3d0a9a3675c597c12c2aa8d"
 
 PR = "r0"
 

--- a/recipes-aws/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-aws/aws-checksums/aws-checksums_0.1.11.bb
@@ -10,9 +10,12 @@ DEPENDS += "\
     aws-c-common \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v0.1.11
+SRCREV = "99bb0ad4b89d335d638536694352c45e0d2188f5"
 
 PR = "r0"
 

--- a/recipes-aws/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.12.6.bb
+++ b/recipes-aws/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2_1.12.6.bb
@@ -11,10 +11,13 @@ DEPENDS += "\
     aws-c-iot \
 "
 
-SRC_URI = "git://github.com/aws/${BPN}.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/aws/${BPN}.git;branch=main \
            file://Add-library-versioning-to-fix-packaging-issues.patch \
            file://Build-static-and-shared-libs.patch \
 "
+
+# v1.12.6
+SRCREV = "df16ccb07cc303e2f7f9b01d8ecb511214025612"
 
 PR = "r0"
 

--- a/recipes-aws/python/python3-awscrt_0.11.20.bb
+++ b/recipes-aws/python/python3-awscrt_0.11.20.bb
@@ -27,7 +27,10 @@ RDEPENDS_${PN} += "\
     ${PYTHON_PN}-netclient \
 "
 
-SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=main;tag=v${PV}"
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=main"
+
+# v0.11.20
+SRCREV = "aa2cf25e5e4bd163e6e88844c8dadc65888b1d10"
 
 PR = "r0"
 

--- a/recipes-aws/s2n/s2n_1.0.5.bb
+++ b/recipes-aws/s2n/s2n_1.0.5.bb
@@ -14,10 +14,12 @@ RDEPENDS_${PN} += "\
     libcrypto \
 "
 
-SRC_URI = "git://github.com/aws/s2n-tls.git;branch=main;tag=v${PV} \
+SRC_URI = "git://github.com/aws/s2n-tls.git;branch=main \
            file://Fix-packaging-issues.patch \
            file://Build-shared-and-static-libs.patch \
            "
+# v1.0.5
+SRCREV = "423dbf15aa63488e0789f681d37a186182c9cb93"
 
 PR = "r0"
 


### PR DESCRIPTION
The tag=v${PV} in SRC_URI doesn't work when add the git sources such as
github.com.awslabs.aws-c-cal.git to PREMIRRORS and set BB_NO_NETWORK = "1":

$ bitbake aws-c-cal -cfetch

ERROR: aws-c-cal-0.5.6-r0 do_fetch: Network access disabled through BB_NO_NETWORK (or set indirectly due to use of BB_FETCH_PREMIRRORONLY) but access requested with command git -c core.fsyncobjectfiles=0 ls-remote git://github.com/awslabs/aws-c-cal.git  (for url git://github.com/awslabs/aws-c-cal.git)

This is because there is no SRCREV, and bitbake needs check the original url to
get it. And we can't set both tag and SRCREV since bitbake would report that as
conflicts, and compared to SRCREV, tag is not reliable enough since it can be
recreated, so use SRCREV to replace tag.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>