### PR TITLE
azure-macro-utils-c: Allow empty base package

### DIFF
--- a/recipes-azure/azure-macro-utils-c/azure-macro-utils-c.inc
+++ b/recipes-azure/azure-macro-utils-c/azure-macro-utils-c.inc
@@ -11,4 +11,6 @@ FILES_${PN}-dev += "\
     ${exec_prefix}/cmake \
 "
 
+ALLOW_EMPTY_${PN} = "1"
+
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
build main package to satisfy -dev dependency

Signed-off-by: Saul Wold <saul.wold@windriver.com>