### PR TITLE
hardknott: Fix do_fetch error for crc32c and use SRCREV to replace tag

### DIFF
--- a/recipes-aws/s2n/s2n_0.10.19.bb
+++ b/recipes-aws/s2n/s2n_0.10.19.bb
@@ -11,11 +11,11 @@ DEPENDS += "\
 "
 
 SRC_URI = "\
-    git://github.com/awslabs/${BPN}.git;branch=main;tag=v${PV} \
+    git://github.com/awslabs/${BPN}.git;branch=main \
     file://Fix-packaging-issues.patch \
 "
 
-PR = "r0"
+SRCREV = "bf2db43b5ac5cc11d536bb8547c1a88bbb474360"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-connectivity/rclone/rclone_1.53.1.bb
+++ b/recipes-connectivity/rclone/rclone_1.53.1.bb
@@ -14,9 +14,9 @@ inherit go-mod
 
 GO_IMPORT = "github.com/rclone/rclone"
 
-SRC_URI = "git://${GO_IMPORT};branch=v1.53-stable;tag=v${PV}"
+SRC_URI = "git://${GO_IMPORT};branch=v1.53-stable"
 
-PR = "r0"
+SRCREV = "043016318039f1aea3f004147c996e38db33d9c3"
 
 do_install_prepend(){
     rm -f ${B}/${GO_BUILD_BINDIR}/bin

--- a/recipes-connectivity/restic/restic_0.10.0.bb
+++ b/recipes-connectivity/restic/restic_0.10.0.bb
@@ -8,9 +8,9 @@ inherit go-mod
 
 GO_IMPORT = "github.com/restic/restic"
 
-SRC_URI = "git://${GO_IMPORT};tag=v${PV}"
+SRC_URI = "git://${GO_IMPORT}"
 
-PR = "r0"
+SRCREV = "40832b2927ab441f8b46561379e6e58b565db4dd"
 
 do_install_prepend(){
     rm -f ${B}/${GO_BUILD_BINDIR}/build-release-binaries

--- a/recipes-support/crc32c/crc32c_1.0.6.bb
+++ b/recipes-support/crc32c/crc32c_1.0.6.bb
@@ -9,7 +9,7 @@ inherit cmake
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/google/crc32c.git;branch=master;tag=${PV} \
+    git://github.com/google/crc32c.git;branch=main;tag=${PV} \
     file://Add-library-versioning.patch \
 "
 

--- a/recipes-support/crc32c/crc32c_1.0.6.bb
+++ b/recipes-support/crc32c/crc32c_1.0.6.bb
@@ -9,9 +9,11 @@ inherit cmake
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/google/crc32c.git;branch=main;tag=${PV} \
+    git://github.com/google/crc32c.git;branch=main \
     file://Add-library-versioning.patch \
 "
+
+SRCREV = "75e82b8bc35fd013a6220427e7f61f8adeebf9b7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Now all recipes on hardknott branch use SRCREV