### PR TITLE
Update SRC_URI branch and protocols

### DIFF
--- a/recipes-aws/aws-c-auth/aws-c-auth_0.5.2.bb
+++ b/recipes-aws/aws-c-auth/aws-c-auth_0.5.2.bb
@@ -11,7 +11,7 @@ DEPENDS += "\
     aws-c-http \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-c-cal/aws-c-cal_0.5.12.bb
+++ b/recipes-aws/aws-c-cal/aws-c-cal_0.5.12.bb
@@ -16,7 +16,7 @@ RDEPENDS:${PN} += " \
 "
 
 SRC_URI = "\
-    git://github.com/awslabs/${BPN}.git;branch=main \
+    git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
     file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-c-common/aws-c-common_0.5.11.bb
+++ b/recipes-aws/aws-c-common/aws-c-common_0.5.11.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 inherit cmake
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
            file://0001-priority_queue.c-fix-compile-error-with-Og.patch \
 "

--- a/recipes-aws/aws-c-compression/aws-c-compression_0.2.11.bb
+++ b/recipes-aws/aws-c-compression/aws-c-compression_0.2.11.bb
@@ -10,7 +10,7 @@ DEPENDS += "\
     aws-c-common \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
 

--- a/recipes-aws/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
+++ b/recipes-aws/aws-c-event-stream/aws-c-event-stream_0.2.7.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-c-http/aws-c-http_0.6.4.bb
+++ b/recipes-aws/aws-c-http/aws-c-http_0.6.4.bb
@@ -11,7 +11,7 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
 

--- a/recipes-aws/aws-c-io/aws-c-io_0.9.9.bb
+++ b/recipes-aws/aws-c-io/aws-c-io_0.9.9.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
     s2n \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
            "
 

--- a/recipes-aws/aws-c-iot/aws-c-iot_0.0.5.bb
+++ b/recipes-aws/aws-c-iot/aws-c-iot_0.0.5.bb
@@ -10,7 +10,7 @@ DEPENDS += "\
     aws-c-mqtt \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
+++ b/recipes-aws/aws-c-mqtt/aws-c-mqtt_0.7.6.bb
@@ -10,7 +10,7 @@ DEPENDS += "\
     aws-c-io \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-c-s3/aws-c-s3_0.1.16.bb
+++ b/recipes-aws/aws-c-s3/aws-c-s3_0.1.16.bb
@@ -10,7 +10,7 @@ DEPENDS += "\
     aws-c-auth \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-checksums/aws-checksums_0.1.11.bb
+++ b/recipes-aws/aws-checksums/aws-checksums_0.1.11.bb
@@ -10,7 +10,7 @@ DEPENDS += "\
     aws-c-common \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main \
            file://Build-static-and-shared-libs.patch \
 "
 

--- a/recipes-aws/aws-crt-cpp/aws-crt-cpp_0.13.7.bb
+++ b/recipes-aws/aws-crt-cpp/aws-crt-cpp_0.13.7.bb
@@ -17,7 +17,7 @@ DEPENDS += "\
     aws-checksums \
 "
 
-SRC_URI = "git://github.com/awslabs/${BPN}.git;branch=main;rev=318ff472a659f5e832812e1567697f9c43aedf13 \
+SRC_URI = "git://github.com/awslabs/${BPN}.git;protocol=https;branch=main;rev=318ff472a659f5e832812e1567697f9c43aedf13 \
            file://Add-library-versioning.patch \
            file://Build-static-and-shared-libs.patch \
            file://Update-cmake-config-file.patch \

--- a/recipes-aws/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
+++ b/recipes-aws/aws-iot-device-sdk-cpp-v2/aws-iot-device-sdk-cpp-v2.inc
@@ -11,7 +11,7 @@ DEPENDS += "\
     aws-c-iot \
 "
 
-SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;branch=main \
+SRC_URI = "git://github.com/aws/aws-iot-device-sdk-cpp-v2.git;protocol=https;branch=main \
            file://Add-library-versioning-to-fix-packaging-issues.patch \
            file://Build-static-and-shared-libs.patch \
            file://0001-samples-mqtt-Install-binary-files.patch \

--- a/recipes-aws/python/python3-awscrt_0.11.20.bb
+++ b/recipes-aws/python/python3-awscrt_0.11.20.bb
@@ -27,7 +27,7 @@ RDEPENDS:${PN} += "\
     ${PYTHON_PN}-netclient \
 "
 
-SRC_URI = "git://github.com/awslabs/aws-crt-python.git;branch=main"
+SRC_URI = "git://github.com/awslabs/aws-crt-python.git;protocol=https;branch=main"
 
 # v0.11.20
 SRCREV = "aa2cf25e5e4bd163e6e88844c8dadc65888b1d10"

--- a/recipes-aws/s2n/s2n_1.1.1.bb
+++ b/recipes-aws/s2n/s2n_1.1.1.bb
@@ -14,7 +14,7 @@ RDEPENDS:${PN} += "\
     libcrypto \
 "
 
-SRC_URI = "git://github.com/aws/s2n-tls.git;branch=main \
+SRC_URI = "git://github.com/aws/s2n-tls.git;protocol=https;branch=main \
            file://Fix-packaging-issues.patch \
            file://Build-shared-and-static-libs.patch \
            "

--- a/recipes-azure/azure-c-shared-utility/azure-c-shared-utility_git.bb
+++ b/recipes-azure/azure-c-shared-utility/azure-c-shared-utility_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 BRANCH = "lts_07_2020"
 SRC_URI = "\
-    git://github.com/Azure/azure-c-shared-utility.git;branch=${BRANCH} \
+    git://github.com/Azure/azure-c-shared-utility.git;protocol=https;branch=${BRANCH} \
 "
 
 SRCREV = "85fe8977e98cc0e84609e9250ba34b0d455b96df"

--- a/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 BRANCH = "lts_07_2020"
 SRC_URI = "\
-    git://github.com/Azure/azure-iot-sdk-c.git;branch=${BRANCH} \
+    git://github.com/Azure/azure-iot-sdk-c.git;protocol=https;branch=${BRANCH} \
 "
 
 SRCREV = "0528d52fc15767f4b3ba535ff35453d4e6b78f07"

--- a/recipes-azure/azure-macro-utils-c/azure-macro-utils-c_git.bb
+++ b/recipes-azure/azure-macro-utils-c/azure-macro-utils-c_git.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 SRC_URI = "\
-    git://github.com/Azure/azure-macro-utils-c.git \
+    git://github.com/Azure/azure-macro-utils-c.git;protocol=https;branch=master \
 "
 
 SRCREV = "3572824c55a1ad3634dd32c1f1dd729e59bbdedc"

--- a/recipes-azure/azure-uamqp-c/azure-uamqp-c_git.bb
+++ b/recipes-azure/azure-uamqp-c/azure-uamqp-c_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 BRANCH = "lts_07_2020"
 SRC_URI = "\
-    git://github.com/Azure/azure-uamqp-c.git;branch=${BRANCH} \
+    git://github.com/Azure/azure-uamqp-c.git;protocol=https;branch=${BRANCH} \
 "
 
 SRCREV = "038b7e32d70bec2b9108f3e3ec999795729ec6fe"

--- a/recipes-azure/azure-uhttp-c/azure-uhttp-c_git.bb
+++ b/recipes-azure/azure-uhttp-c/azure-uhttp-c_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=b98fddd052bb2f5ddbcdbd417ffb26a8"
 
 BRANCH = "lts_07_2020"
 SRC_URI = "\
-    git://github.com/Azure/azure-uhttp-c.git;branch=${BRANCH} \
+    git://github.com/Azure/azure-uhttp-c.git;protocol=https;branch=${BRANCH} \
 "
 
 SRCREV = "6f18cb8e7f98dc875f37906aec3feeb3b5b9ef5f"

--- a/recipes-azure/azure-umqtt-c/azure-umqtt-c_git.bb
+++ b/recipes-azure/azure-umqtt-c/azure-umqtt-c_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=6e1bb384cedd6442b3a2b9a5b531e005"
 
 BRANCH = "lts_07_2020"
 SRC_URI = "\
-    git://github.com/Azure/azure-umqtt-c.git;branch=${BRANCH} \
+    git://github.com/Azure/azure-umqtt-c.git;protocol=https;branch=${BRANCH} \
 "
 
 SRCREV="0c9cd1b323e58816fafe8d4db303b17ac2101b19"

--- a/recipes-azure/umock-c/umock-c_git.bb
+++ b/recipes-azure/umock-c/umock-c_git.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4f9c2c296f77b3096b6c11a16fa7c66e"
 
 SRC_URI = "\
-    git://github.com/Azure/umock-c.git \
+    git://github.com/Azure/umock-c.git;protocol=https;branch=master \
 "
 
 SRCREV = "062f7e5c34f7eb9a7e10c352364f4057fd67607a"

--- a/recipes-devtools/python/python-dicttoxml.inc
+++ b/recipes-devtools/python/python-dicttoxml.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENCE.txt;md5=8c6f370c9073badc24ad75afa6822bcb"
 
 PR = "r0"
 
-SRC_URI = "git://github.com/quandyfactory/dicttoxml.git"
+SRC_URI = "git://github.com/quandyfactory/dicttoxml.git;protocol=https;branch=master"
 SRCREV = "2016fe9817ad03b26aa5f1a475f5b79ad6757b96"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-dill.inc
+++ b/recipes-devtools/python/python-dill.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca6e0344ddc8af7ac5897ed5f5cc0cc2"
 
 PR = "r0"
 
-SRC_URI = "git://github.com/uqfoundation/dill.git"
+SRC_URI = "git://github.com/uqfoundation/dill.git;protocol=https;branch=master"
 SRCREV = "afaeb815ecae56e9de6fe19f376deecdc272e32f"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-repoze-lru.inc
+++ b/recipes-devtools/python/python-repoze-lru.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=2c33cdbc6bc9ae6e5d64152fdb754292"
 
 PR = "r0"
 
-SRC_URI = "git://github.com/repoze/repoze.lru.git"
+SRC_URI = "git://github.com/repoze/repoze.lru.git;protocol=https;branch=master"
 SRCREV = "29c8281dee7fe8dae8c66c7c40ce7c058ec2ab0f"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-routes.inc
+++ b/recipes-devtools/python/python-routes.inc
@@ -20,7 +20,7 @@ RCONFLICTS:${PN} += "routes"
 
 PR = "r2"
 
-SRC_URI = "git://github.com/bbangert/routes.git"
+SRC_URI = "git://github.com/bbangert/routes.git;protocol=https;branch=main"
 SRCREV = "0900d346e5569018644dcee850d679de3c915efb"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-scandir.inc
+++ b/recipes-devtools/python/python-scandir.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=482ee62da51806409d432a80eed4e3ea"
 
 PR = "r0"
 
-SRC_URI = "git://github.com/benhoyt/scandir.git"
+SRC_URI = "git://github.com/benhoyt/scandir.git;protocol=https;branch=master"
 SRCREV = "edbae30f83f370f9d2f1e43d02e3793081e1cd25"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-webob.inc
+++ b/recipes-devtools/python/python-webob.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://docs/license.txt;md5=8ed3584bcc78c16da363747ccabc5af5
 
 PR = "r0"
 
-SRC_URI = "git://github.com/Pylons/webob.git;branch=1.7-branch"
+SRC_URI = "git://github.com/Pylons/webob.git;protocol=https;branch=1.7-branch"
 SRCREV = "c4cee625e5b0b0f410e22ca60f701eff98f288d0"
 
 S = "${WORKDIR}/git"

--- a/recipes-devtools/python/python-webrtcvad.inc
+++ b/recipes-devtools/python/python-webrtcvad.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=425b45e5a79ac786f2f8e977a3beaad4"
 
 PR = "r0"
 
-SRC_URI = "git://github.com/wiseman/py-webrtcvad.git"
+SRC_URI = "git://github.com/wiseman/py-webrtcvad.git;protocol=https;branch=master"
 SRCREV = "bb429dac1a686807c69b916f03dd843fa10b0927"
 
 S = "${WORKDIR}/git"

--- a/recipes-support/cjson/cjson_1.7.10.bb
+++ b/recipes-support/cjson/cjson_1.7.10.bb
@@ -9,7 +9,7 @@ inherit cmake pkgconfig
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/DaveGamble/cJSON.git \
+    git://github.com/DaveGamble/cJSON.git;protocol=https;branch=master \
 "
 
 SRCREV = "c69134d01746dcf551dd7724b4edb12f922eb0d1"

--- a/recipes-support/crc32c/crc32c_1.0.6.bb
+++ b/recipes-support/crc32c/crc32c_1.0.6.bb
@@ -9,7 +9,7 @@ inherit cmake
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/google/crc32c.git;branch=master;tag=${PV} \
+    git://github.com/google/crc32c.git;protocol=https;branch=master;tag=${PV} \
     file://Add-library-versioning.patch \
 "
 

--- a/recipes-support/http-parser/http-parser_2.8.1.bb
+++ b/recipes-support/http-parser/http-parser_2.8.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/nodejs/http-parser"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE-MIT;md5=9bfa835d048c194ab30487af8d7b3778"
 
-SRC_URI = "git://github.com/nodejs/http-parser.git"
+SRC_URI = "git://github.com/nodejs/http-parser.git;protocol=https;branch=main"
 SRCREV = "54f55a2f02a823e5f5c87abe853bb76d1170718d"
 
 PR = "r0"

--- a/recipes-support/parson/parson_1.1.0.bb
+++ b/recipes-support/parson/parson_1.1.0.bb
@@ -9,7 +9,7 @@ inherit cmake pkgconfig
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/kgabis/parson.git;rev=102a4467e10c77ffcfde1d233798780acd719cc5 \
+    git://github.com/kgabis/parson.git;protocol=https;rev=102a4467e10c77ffcfde1d233798780acd719cc5 \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This PR is being made since setting a default branch and using https for GitHub urls (GitHub no longer supports the git protocol) will soon be required for all layers. Currently, you will just see a warning when running bitbake.

Update SRC_URIs using git to include branch=master or branch=main if no branch is set and also to use protocol=https for github urls.