### PR TITLE
Fix openssl 3.x compatibility

### DIFF
--- a/recipes-azure/azure-c-shared-utility/azure-c-shared-utility.inc
+++ b/recipes-azure/azure-c-shared-utility/azure-c-shared-utility.inc
@@ -16,6 +16,7 @@ SRC_URI += "\
     file://Fix-packaging-issues.patch \
     file://Use-pkg-config-to-find-libs.patch \
     file://0001-hmac.c-fix-compile-error-for-digest-pointer-vs-array.patch \
+    file://0001-Fix-openssl-3.x-compatibility.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-azure/azure-c-shared-utility/files/0001-Fix-openssl-3.x-compatibility.patch
+++ b/recipes-azure/azure-c-shared-utility/files/0001-Fix-openssl-3.x-compatibility.patch
@@ -1,0 +1,73 @@
+From 514b166bd0aab39730bf8973671fc8ac2aab85c3 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 14 Dec 2021 17:51:08 +0800
+Subject: [PATCH] Fix openssl 3.x compatibility
+
+Skip deprecated-declarations error, still use deprecated functions in
+openssl 3.x
+
+Bump OPENSSL_VERSION_NUMBER to less than 0x40000000L which these APIs
+are still supported in openssl 3.x
+
+Upstream-Status: Pending
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ CMakeLists.txt           | 4 ++--
+ adapters/tlsio_openssl.c | 2 +-
+ adapters/x509_openssl.c  | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f1cf06fe..c8c0f9d5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -182,8 +182,8 @@ elseif(LINUX) #LINUX OR APPLE
+         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_WOLFSSL")
+     endif()
+     # Turn off warning that can not be fixed right now
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
+-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-deprecated-declarations")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-deprecated-declarations")
+ elseif(APPLE)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat-security")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat-security")
+diff --git a/adapters/tlsio_openssl.c b/adapters/tlsio_openssl.c
+index a73c129c..c3efd189 100644
+--- a/adapters/tlsio_openssl.c
++++ b/adapters/tlsio_openssl.c
+@@ -866,7 +866,7 @@ static int add_certificate_to_store(TLS_IO_INSTANCE* tls_io_instance, const char
+         }
+         else
+         {
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x40000000L)
+             const BIO_METHOD* bio_method;
+ #else
+             BIO_METHOD* bio_method;
+diff --git a/adapters/x509_openssl.c b/adapters/x509_openssl.c
+index 11be7a03..36302b7b 100644
+--- a/adapters/x509_openssl.c
++++ b/adapters/x509_openssl.c
+@@ -73,7 +73,7 @@ static int load_certificate_chain(SSL_CTX* ssl_ctx, const char* certificate)
+                 // certificates.
+ 
+                 /* Codes_SRS_X509_OPENSSL_07_006: [ If successful x509_openssl_add_ecc_credentials shall to import each certificate in the cert chain. ] */
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x40000000L)
+                 SSL_CTX_clear_extra_chain_certs(ssl_ctx);
+ #else
+                 if (ssl_ctx->extra_certs != NULL)
+@@ -264,7 +264,7 @@ int x509_openssl_add_certificates(SSL_CTX* ssl_ctx, const char* certificates)
+         else
+         {
+             /*Codes_SRS_X509_OPENSSL_02_012: [ x509_openssl_add_certificates shall get the memory BIO method function by calling BIO_s_mem. ]*/
+-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x40000000L)
+             const BIO_METHOD* bio_method;
+ #else
+             BIO_METHOD* bio_method;
+-- 
+2.27.0
+

--- a/recipes-azure/azure-c-shared-utility/files/Use-pkg-config-to-find-libs.patch
+++ b/recipes-azure/azure-c-shared-utility/files/Use-pkg-config-to-find-libs.patch
@@ -1,15 +1,28 @@
-From 03947c2a47bf7458ed093355e71a4f411a725330 Mon Sep 17 00:00:00 2001
+From fea2b8280b0889b5c03f628c498cae7125f2a64c Mon Sep 17 00:00:00 2001
 From: Scott Ware <scott.r.ware@intel.com>
 Date: Tue, 7 Apr 2020 20:59:53 +0100
-Subject: [PATCH 2/2] Use pkg-config to find libs
+Subject: [PATCH] Use pkg-config to find libs
 
 Signed-off-by: Scott Ware <scott.r.ware@intel.com>
+
+Add link options to cmake configs. Other package (such as
+azure-iot-sdk-c) link library of azure-c-shared-utility
+with these options to avoid the following error
+...
+ld: iothub_client/libiothub_client.so.1.4.1: undefined reference to `ERR_load_BIO_strings'
+collect2: error: ld returned 1 exit status
+...
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
 ---
- CMakeLists.txt | 31 ++++++++++---------------------
- 1 file changed, 10 insertions(+), 21 deletions(-)
+ CMakeLists.txt                      | 31 ++++++++++-------------------
+ configs/azure_iot_build_rules.cmake |  5 +++++
+ 2 files changed, 15 insertions(+), 21 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5251ffe..52ab416 100644
+index e7078fee..c8c0f9d5 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -116,9 +116,13 @@ if(${use_openssl})
@@ -67,6 +80,22 @@ index 5251ffe..52ab416 100644
      if (WIN32)
          set(aziotsharedutil_target_libs ${aziotsharedutil_target_libs} crypt32 ws2_32 secur32)
      endif()
+diff --git a/configs/azure_iot_build_rules.cmake b/configs/azure_iot_build_rules.cmake
+index be3e14fe..4f85a2b8 100644
+--- a/configs/azure_iot_build_rules.cmake
++++ b/configs/azure_iot_build_rules.cmake
+@@ -76,6 +76,11 @@ elseif(UNIX) #LINUX OR APPLE
+     if(NOT (IN_OPENWRT OR APPLE))
+         set (CMAKE_C_FLAGS "-D_POSIX_C_SOURCE=200112L ${CMAKE_C_FLAGS}")
+     endif()
++
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lssl -lcrypto")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lssl -lcrypto")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lcurl")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lcurl")
+ endif()
+ 
+ enable_testing()
 -- 
-2.7.4
+2.27.0
 

--- a/recipes-core/packagegroups/packagegroup-cloud-azure_0.20.bb
+++ b/recipes-core/packagegroups/packagegroup-cloud-azure_0.20.bb
@@ -1,6 +1,8 @@
 DESCRIPTION = "Packages for Microsoft Azure IoT."
 LICENSE = "MIT"
 
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 PR = "r0"
@@ -23,3 +25,4 @@ PACKAGECONFIG[python] = "\
     , \
     python3-azure-iot-device \
 "
+


### PR DESCRIPTION
For azure-c-shared-utility, upstream don't support OpenSSL 3.0.
at the moment [1], we have to workaround it by still using deprecated
functions in openssl 3.x

[1] https://github.com/Azure/azure-c-shared-utility/issues/565