### PR TITLE
s2n: fix build with gcc-12

### DIFF
--- a/recipes-aws/s2n/s2n/0001-Changed-function-declarations-to-match-their-definit.patch
+++ b/recipes-aws/s2n/s2n/0001-Changed-function-declarations-to-match-their-definit.patch
@@ -1,0 +1,130 @@
+From 7c6fed703bd060db6342c2d63e209eddf8f4c0ff Mon Sep 17 00:00:00 2001
+From: maddeleine <59030281+maddeleine@users.noreply.github.com>
+Date: Wed, 23 Mar 2022 09:52:38 -0700
+Subject: [PATCH] Changed function declarations to match their definitions
+ (#3243)
+
+Upstream-Status: Backport [https://github.com/aws/s2n-tls/commit/7c6fed703bd060db6342c2d63e209eddf8f4c0ff]
+
+Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
+---
+ pq-crypto/kyber_90s_r2/ntt.h                 | 4 ++--
+ pq-crypto/kyber_r2/ntt.h                     | 4 ++--
+ pq-crypto/kyber_r3/kyber512r3_poly_avx2.h    | 4 ++--
+ pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h | 4 ++--
+ pq-crypto/sike_r1/P503_internal_r1.h         | 2 +-
+ pq-crypto/sike_r1/fips202_r1.h               | 2 +-
+ tls/s2n_cipher_suites.c                      | 2 +-
+ 7 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/pq-crypto/kyber_90s_r2/ntt.h b/pq-crypto/kyber_90s_r2/ntt.h
+index 720bee97..66fc5a94 100644
+--- a/pq-crypto/kyber_90s_r2/ntt.h
++++ b/pq-crypto/kyber_90s_r2/ntt.h
+@@ -6,8 +6,8 @@
+ extern const int16_t PQCLEAN_KYBER51290S_CLEAN_zetas[128];
+ extern const int16_t PQCLEAN_KYBER51290S_CLEAN_zetasinv[128];
+ 
+-void PQCLEAN_KYBER51290S_CLEAN_ntt(int16_t *poly);
+-void PQCLEAN_KYBER51290S_CLEAN_invntt(int16_t *poly);
++void PQCLEAN_KYBER51290S_CLEAN_ntt(int16_t poly[256]);
++void PQCLEAN_KYBER51290S_CLEAN_invntt(int16_t poly[256]);
+ void PQCLEAN_KYBER51290S_CLEAN_basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
+ 
+ #endif
+diff --git a/pq-crypto/kyber_r2/ntt.h b/pq-crypto/kyber_r2/ntt.h
+index 13e976f7..7885e7cd 100644
+--- a/pq-crypto/kyber_r2/ntt.h
++++ b/pq-crypto/kyber_r2/ntt.h
+@@ -6,8 +6,8 @@
+ extern const int16_t PQCLEAN_KYBER512_CLEAN_zetas[128];
+ extern const int16_t PQCLEAN_KYBER512_CLEAN_zetasinv[128];
+ 
+-void PQCLEAN_KYBER512_CLEAN_ntt(int16_t *poly);
+-void PQCLEAN_KYBER512_CLEAN_invntt(int16_t *poly);
++void PQCLEAN_KYBER512_CLEAN_ntt(int16_t poly[256]);
++void PQCLEAN_KYBER512_CLEAN_invntt(int16_t poly[256]);
+ void PQCLEAN_KYBER512_CLEAN_basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
+ 
+ #endif
+diff --git a/pq-crypto/kyber_r3/kyber512r3_poly_avx2.h b/pq-crypto/kyber_r3/kyber512r3_poly_avx2.h
+index 56e240b0..bd6e857f 100644
+--- a/pq-crypto/kyber_r3/kyber512r3_poly_avx2.h
++++ b/pq-crypto/kyber_r3/kyber512r3_poly_avx2.h
+@@ -37,7 +37,7 @@ void poly_getnoise_eta1_4x(poly *r0,
+                            poly *r1,
+                            poly *r2,
+                            poly *r3,
+-                           const uint8_t *seed,
++                           const uint8_t seed[32],
+                            uint8_t nonce0,
+                            uint8_t nonce1,
+                            uint8_t nonce2,
+@@ -48,7 +48,7 @@ void poly_getnoise_eta1122_4x(poly *r0,
+                               poly *r1,
+                               poly *r2,
+                               poly *r3,
+-                              const uint8_t *seed,
++                              const uint8_t seed[32],
+                               uint8_t nonce0,
+                               uint8_t nonce1,
+                               uint8_t nonce2,
+diff --git a/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h b/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h
+index bf6f664a..536e1b23 100644
+--- a/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h
++++ b/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h
+@@ -11,10 +11,10 @@ typedef struct{
+ } polyvec;
+ 
+ #define polyvec_compress_avx2 S2N_KYBER_512_R3_NAMESPACE(polyvec_compress_avx2)
+-void polyvec_compress_avx2(uint8_t r[S2N_KYBER_512_R3_POLYCOMPRESSEDBYTES+2], const polyvec *a);
++void polyvec_compress_avx2(uint8_t r[S2N_KYBER_512_R3_POLYVECCOMPRESSEDBYTES+2], const polyvec *a);
+ 
+ #define polyvec_decompress_avx2 S2N_KYBER_512_R3_NAMESPACE(polyvec_decompress_avx2)
+-void polyvec_decompress_avx2(polyvec *r, const uint8_t a[S2N_KYBER_512_R3_POLYCOMPRESSEDBYTES+12]);
++void polyvec_decompress_avx2(polyvec *r, const uint8_t a[S2N_KYBER_512_R3_POLYVECCOMPRESSEDBYTES+12]);
+ 
+ #define polyvec_tobytes_avx2 S2N_KYBER_512_R3_NAMESPACE(polyvec_tobytes_avx2)
+ void polyvec_tobytes_avx2(uint8_t r[S2N_KYBER_512_R3_POLYVECBYTES], const polyvec *a);
+diff --git a/pq-crypto/sike_r1/P503_internal_r1.h b/pq-crypto/sike_r1/P503_internal_r1.h
+index f6674fa2..64465f19 100644
+--- a/pq-crypto/sike_r1/P503_internal_r1.h
++++ b/pq-crypto/sike_r1/P503_internal_r1.h
+@@ -150,7 +150,7 @@ void fpdiv2_503(const digit_t* a, digit_t* c);
+ void fpcorrection503(digit_t* a);
+ 
+ // 503-bit Montgomery reduction, c = a mod p
+-void rdc_mont(const digit_t* a, digit_t* c);
++void rdc_mont(const dfelm_t ma, felm_t mc);
+ 
+ // Field multiplication using Montgomery arithmetic, c = a*b*R^-1 mod p503, where R=2^768
+ void fpmul503_mont(const felm_t a, const felm_t b, felm_t c);
+diff --git a/pq-crypto/sike_r1/fips202_r1.h b/pq-crypto/sike_r1/fips202_r1.h
+index 128a0127..983537c2 100644
+--- a/pq-crypto/sike_r1/fips202_r1.h
++++ b/pq-crypto/sike_r1/fips202_r1.h
+@@ -7,7 +7,7 @@
+ #define SHAKE128_RATE 168
+ #define SHAKE256_RATE 136
+ 
+-void cshake256_simple_absorb(uint64_t *s, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
++void cshake256_simple_absorb(uint64_t s[25], uint16_t cstm, const unsigned char *in, unsigned long long inlen);
+ void cshake256_simple(unsigned char *output, unsigned long long outlen, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
+ 
+ #endif // FIPS202_R1_H
+diff --git a/tls/s2n_cipher_suites.c b/tls/s2n_cipher_suites.c
+index 91911d97..cf82b7c6 100644
+--- a/tls/s2n_cipher_suites.c
++++ b/tls/s2n_cipher_suites.c
+@@ -1088,7 +1088,7 @@ int s2n_cipher_suites_cleanup(void)
+     return 0;
+ }
+ 
+-S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite)
++S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[static S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite)
+ {
+     RESULT_ENSURE_REF(cipher_suite);
+     *cipher_suite = NULL;
+-- 
+2.25.1
+

--- a/recipes-aws/s2n/s2n_1.1.1.bb
+++ b/recipes-aws/s2n/s2n_1.1.1.bb
@@ -18,6 +18,7 @@ SRC_URI = "git://github.com/aws/s2n-tls.git;protocol=https;branch=main \
            file://Fix-packaging-issues.patch \
            file://0001-Workaround-gcc-11-errors.patch \
            file://Build-shared-and-static-libs.patch \
+           file://0001-Changed-function-declarations-to-match-their-definit.patch \
            "
 # v1.0.5
 SRCREV = "4513f8d707a68388990886d353e7cfe46cc6454b"


### PR DESCRIPTION
Backport patch [1] to fix the build failure with gcc-12.
 | In function '_mm256_loadu_si256',
 | inlined from 'poly_decompress10' at /build/tmp-glibc/work/corei7-64-wrs-linux/s2n/1.1.1-r0/git/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.c:66:9,
 | inlined from 's2n_kyber_512_r3_polyvec_decompress_avx2' at /build/tmp-glibc/work/corei7-64-wrs-linux/s2n/1.1.1-r0/git/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.c:109:5:
 | /build/tmp-glibc/work/corei7-64-wrs-linux/s2n/1.1.1-r0/recipe-sysroot-native/usr/lib/x86_64-wrs-linux/gcc/x86_64-wrs-linux/12.1.0/include/avxintrin.h:929:10: error: array subscript [10, 19] is outside array bounds of 'const uint8_t[140]' {aka 'const unsigned char[140]'} [-Werror=array-bounds]
 | 929 | return *__P;
 | ^~~~

[1] https://github.com/aws/s2n-tls/commit/7c6fed703bd060db6342c2d63e209eddf8f4c0ff

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>