### PR TITLE
crc32c: Fix branch name, replace tag with SRCREV

### DIFF
--- a/recipes-support/crc32c/crc32c_1.0.6.bb
+++ b/recipes-support/crc32c/crc32c_1.0.6.bb
@@ -9,9 +9,11 @@ inherit cmake
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/google/crc32c.git;protocol=https;branch=master;tag=${PV} \
+    git://github.com/google/crc32c.git;protocol=https;branch=main \
     file://Add-library-versioning.patch \
 "
+
+SRCREV = "75e82b8bc35fd013a6220427e7f61f8adeebf9b7"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The SRC_URI branch name has changed, and bitbake doesn't like the tag. The hardknott branch uses SRCREV, I'm guessing that is the preferred way to do it? I'm using the kirkstone branch, but the same should apply to main as well.