### PR TITLE
python3-azure-iot-cloud: fix do_compile error with new setuptools

### DIFF
--- a/recipes-azure/python/python3-azure-iot-device/0001-setup.py-fit-new-setuptools.patch
+++ b/recipes-azure/python/python3-azure-iot-device/0001-setup.py-fit-new-setuptools.patch
@@ -1,0 +1,37 @@
+From 7351a68b1c7c6467a03e4a57b1c96ae503972ca9 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Thu, 16 Feb 2023 18:43:11 +0800
+Subject: [PATCH] setup.py: fit new setuptools
+
+Fix setup.py to fit new setuptools, other we get the following
+error at build.
+
+  error in azure-iot-device setup command: 'python_requires' must
+  be a string containing valid version specifiers; Invalid specifier: '!=3.3*'
+
+This patch is not sent to upstream because this package
+has a new version which does not have this problem.
+
+Upstream-Status: Inappropriate [OE Specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 33c5b74..fecdf7f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -93,7 +93,7 @@ setup(
+         "win-inet-pton;python_version == '2.7'",
+     ],
+     extras_require={":python_version<'3.0'": ["azure-iot-nspkg>=1.0.1"]},
+-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3*, <4",
++    python_requires=">=3.4, <4",
+     packages=find_packages(
+         exclude=[
+             "tests",
+-- 
+2.17.1
+

--- a/recipes-azure/python/python3-azure-iot-device_2.3.0.bb
+++ b/recipes-azure/python/python3-azure-iot-device_2.3.0.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 inherit pypi setuptools3
 
+SRC_URI += "file://0001-setup.py-fit-new-setuptools.patch"
+
 RDEPENDS:${PN} += "\
     ${PYTHON_PN}-asyncio \
     ${PYTHON_PN}-crypt \


### PR DESCRIPTION
We get the following error at build.

  error in azure-iot-device setup command: 'python_requires'
  must be a string containing valid version specifiers; Invalid specifier: '!=3.3*'

This is because new setuptools does not allow such specifier. Change to use >=3.4 to fix this issue.