### PR TITLE
node-red: remove temporary files from correct directory

### DIFF
--- a/recipes-devtools/node-red/node-red_3.0.2.bb
+++ b/recipes-devtools/node-red/node-red_3.0.2.bb
@@ -23,12 +23,12 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/${BPN}.service ${D}${systemd_unitdir}/system/
 
     # Remove hardware specific files
-    rm ${D}/${bindir}/${BPN}-pi
-    rm -rf ${D}/${libdir}/node_modules/${BPN}/bin
+    rm -v ${D}/${bindir}/${BPN}-pi
+    rm -rvf ${D}${nonarch_libdir}/node_modules/${BPN}/bin
 
     # Remove tmp files
-    rm -rf ${D}/${libdir}/node_modules/${BPN}/node_modules/bcrypt/build-tmp-napi-v3
-    rm -rf ${D}/${libdir}/node_modules/${BPN}/node_modules/bcrypt/node-addon-api
+    rm -rvf ${D}${nonarch_libdir}/node_modules/${BPN}/node_modules/bcrypt/build-tmp-napi-v3
+    rm -rvf ${D}${nonarch_libdir}/node_modules/${BPN}/node_modules/bcrypt/node-addon-api
 }
 
 inherit systemd


### PR DESCRIPTION
* npm.bbclass copies the 'lib' into nonarch_libdir not regular libdir: https://git.openembedded.org/openembedded-core/tree/meta/classes-recipe/npm.bbclass?h=scarthgap#n310

* on builds where libdir != nonarch_libdir (e.g. with multilib) this fails, because build-tmp-napi-v3 wasn't removed in do_install:

  ERROR: QA Issue: Symlink /usr/lib/node_modules/node-red/node_modules/bcrypt/build-tmp-napi-v3/node_gyp_bins/python3 in node-red points to TMPDIR [symlink-to-sysroot]
  ERROR: QA Issue: non -staticdev package contains static .a library: node-red path '/usr/lib/node_modules/node-red/node_modules/bcrypt/build-tmp-napi-v3/Release/nothing.a'
                   non -staticdev package contains static .a library: node-red path '/usr/lib/node_modules/node-red/node_modules/bcrypt/build-tmp-napi-v3/Release/node-addon-api/nothing.a' [staticdev]

* add -v to show in the logs what is being removed