### PR TITLE
Fix parse errors caused by SRC_URI

### DIFF
--- a/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -5,8 +5,10 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 SRC_URI = "\
-    git://github.com/Azure/azure-iot-sdk-c.git;protocol=https;branch=main;tag=LTS_03_2024 \
+    git://github.com/Azure/azure-iot-sdk-c.git;protocol=https;branch=main \
 "
+
+SRCREV = "09d4e9ca46d1facea7d6d0c7ac13e56edd0a715f"
 
 PV = "1.13.0+git${SRCPV}"
 

--- a/recipes-connectivity/rclone/rclone_1.66.0.bb
+++ b/recipes-connectivity/rclone/rclone_1.66.0.bb
@@ -15,5 +15,6 @@ inherit go-mod
 GO_IMPORT = "github.com/rclone/rclone"
 GO_INSTALL = "${GO_IMPORT}"
 
-SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https;tag=v${PV}"
+SRC_URI = "git://${GO_IMPORT}.git;branch=master;protocol=https"
 
+SRCREV = "b6013a5e689ff4ff8a869aa262c9d04d454f5a71"

--- a/recipes-devtools/python/python3-libcst_1.3.1.bb
+++ b/recipes-devtools/python/python3-libcst_1.3.1.bb
@@ -15,8 +15,10 @@ require ${BPN}-crates.inc
 PR = "r0"
 
 SRC_URI += "\
-    git://github.com/Instagram/LibCST.git;protocol=https;branch=main;tag=v${PV} \
+    git://github.com/Instagram/LibCST.git;protocol=https;branch=main \
 "
+
+SRCREV = "9f54920d9d32a519aa1702485ed56c55d8189a0c"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-google-cloud/google-cloud-cpp/google-cloud-cpp_2.23.0.bb
+++ b/recipes-google-cloud/google-cloud-cpp/google-cloud-cpp_2.23.0.bb
@@ -5,9 +5,11 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "\
-    git://github.com/googleapis/google-cloud-cpp.git;protocol=https;branch=main;tag=v${PV} \
+    git://github.com/googleapis/google-cloud-cpp.git;protocol=https;branch=main \
     file://0001-Remove-compiler-flags-from-build-info.patch \
 "
+
+SRCREV = "60768edc006fcdf97bb01c604d04cd47ccec668b"
 
 include ${BPN}.inc
 

--- a/recipes-support/crc32c/crc32c_1.1.2.bb
+++ b/recipes-support/crc32c/crc32c_1.1.2.bb
@@ -9,8 +9,10 @@ inherit cmake
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/google/crc32c.git;protocol=https;branch=main;tag=${PV} \
+    git://github.com/google/crc32c.git;protocol=https;branch=main \
 "
+
+SRCREV = "02e65f4fd3065d27b2e29324800ca6d04df16126"
 
 S = "${WORKDIR}/git"
 
@@ -22,4 +24,3 @@ EXTRA_OECMAKE += "\
 "
 
 BBCLASSEXTEND = "native nativesdk"
-

--- a/recipes-support/nlohmann-json/nlohmann-json_3.11.3.bb
+++ b/recipes-support/nlohmann-json/nlohmann-json_3.11.3.bb
@@ -9,8 +9,10 @@ inherit cmake pkgconfig
 PR = "r0"
 
 SRC_URI = "\
-    git://github.com/nlohmann/json.git;protocol=https;branch=master;tag=v${PV} \
+    git://github.com/nlohmann/json.git;protocol=https;branch=master \
 "
+
+SRCREV = "9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
It fails to parse the recipes which use `tag` option in SRC_URI, such as

| ERROR: ExpansionError during parsing meta-iot-cloud/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb |
| The variable dependency chain for the failure is: fetcher_hashes_dummyfunc[vardepvalue]

Remove the option `tag` and SRC_URI and add SRCREV for each recipe to fix the errors.