### PR TITLE
submodules are not fetched while bitbaking the azure-iot-sdk-c

### DIFF
--- a/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4283671594edec4c13aeb073c219237a"
 
 SRC_URI = "\
-    git://github.com/Azure/azure-iot-sdk-c.git;protocol=https;branch=main \
+    gitsm://github.com/Azure/azure-iot-sdk-c.git;protocol=https;branch=main \
 "
 
 SRCREV = "09d4e9ca46d1facea7d6d0c7ac13e56edd0a715f"


### PR DESCRIPTION
CMake Error at provisioning_client/deps/CMakeLists.txt:135 (add_subdirectory):
  The source directory

    /home/prashant/yocto/build/tmp/work/armv7ahf-neon-poky-linux-gnueabi/azure-iot-sdk-c/lts_08_2023+git/git/provisioning_client/deps/utpm

  does not contain a CMakeLists.txt file.



-- Configuring incomplete, errors occurred!

+ bb_bash_exit_handler