### PR TITLE
layer.conf: Add Walnascar to compatibility list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILES += "\
 BBFILE_COLLECTIONS += "iot-cloud"
 BBFILE_PATTERN_iot-cloud := "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot-cloud = "10"
-LAYERSERIES_COMPAT_iot-cloud = "scarthgap"
+LAYERSERIES_COMPAT_iot-cloud = "scarthgap walnascar"
 LAYERDEPENDS_iot-cloud = "\
     core \
     openembedded-layer \


### PR DESCRIPTION
There has been two releases since Scarthgap: Styhead and Walnascar with Whinlatter being the release next up:

  - Styhead is out of support
  - Walnascar is currently being supported
  - Whinlatter needs further changes probably as `S = "${WORKDIR}/..."` is no longer allowed

Therefore add only `walnascar` to the compatible list.